### PR TITLE
archive/dasharo_onboarding.md: fix flashrom command

### DIFF
--- a/archive/dasharo-onboarding.md
+++ b/archive/dasharo-onboarding.md
@@ -76,6 +76,16 @@ further, there is need for only `make` command.
 # Flash Process
 * Mainly, process is described in instruction.
 * Flashing is performed on target device, itself.
+* Before attempting flashing make sure the `BIOS lock` is turned off, otherwise
+flashing will fail.
+     - make sure the laptop is powered off
+     - turn on the device
+     - wait for the splash screen
+     - press key for `Setup`
+        - Alternatively press the key for one-time boot menu and choose `Setup`
+     - Select `Dasharo System Features`
+     - Select `Dasharo Security Options`
+     - Make sure the option `Lock the BIOS boot medium` is unchecked
 * To enter flashing mode, device should be booted properly:
  - make sure laptop is powered off
  - turn on the device

--- a/archive/dasharo-onboarding.md
+++ b/archive/dasharo-onboarding.md
@@ -101,7 +101,7 @@ scp build/coreboot.rom root@<here IP of NVC laptop>/tmp
 ```
 ssh root@<here IP of NVC laptop
 cd /tmp
-flashrom -p internal -i RW_SECTION_A --fmap -w /tmp/coreboot.rom
+flashrom -p internal --ifd -i bios -w /tmp/coreboot.rom
 ```
 * After finishing(still, under ssh):
 ```

--- a/dug_6_osfv.md
+++ b/dug_6_osfv.md
@@ -28,10 +28,10 @@ class: center, middle, intro
   - testing Dasharo firmware releases
   - test-driven bug fixing (and adding new features)
   - regression testing
-      + after introducing new features
-      + after major changes (update base from upstream project)
+    + after introducing new features
+    + after major changes (update base from upstream project)
   - validation of Dasharo related tools (DTS, DCU)
-      + where possible, in QEMU
+    + where possible, in QEMU
 
 .center.image-20[![](/img/Robot-framework-logo.png)]
 


### PR DESCRIPTION
The old command would work if we were updating between two official Dasharo releases which are properly signed but it is not the case. The whole bios region needs to be flashed, not just the RW_SECTION_A. The new command is taken from https://docs.dasharo.com/dasharo-tools-suite/documentation/#features.