### PR TITLE
archive/dasharo_onboarding.md: Extend ssh identity warning troubleshooting

### DIFF
--- a/archive/dasharo-onboarding.md
+++ b/archive/dasharo-onboarding.md
@@ -133,6 +133,9 @@ Solution is in the line:
 ```
 ssh-keygen -f "/home/coreboot/.ssh/known_hosts" -R "192.168.4.236"
 ```
+Another solution is to manually edit the `known_hosts` file using a text editor and deleting the lines corresponding to the host. In this example the message says `/home/coreboot/.ssh/known_hosts:1` which means we need to delete line number `1` in the `/home/coreboot/.ssh/known_hosts` file.
+Generally we should be cautious when receiving this warning, but in this case it is expected for the warning to appear every time we are network booting.
+
 ---
 # Recovery
 

--- a/archive/dasharo-onboarding.md
+++ b/archive/dasharo-onboarding.md
@@ -133,8 +133,12 @@ Solution is in the line:
 ```
 ssh-keygen -f "/home/coreboot/.ssh/known_hosts" -R "192.168.4.236"
 ```
-Another solution is to manually edit the `known_hosts` file using a text editor and deleting the lines corresponding to the host. In this example the message says `/home/coreboot/.ssh/known_hosts:1` which means we need to delete line number `1` in the `/home/coreboot/.ssh/known_hosts` file.
-Generally we should be cautious when receiving this warning, but in this case it is expected for the warning to appear every time we are network booting.
+Another solution is to manually edit the `known_hosts` file using a text
+editor and deleting the lines corresponding to the host. In this example
+the message says `/home/coreboot/.ssh/known_hosts:1` which means we
+need to delete line number `1` in the `/home/coreboot/.ssh/known_hosts` file.
+Generally we should be cautious when receiving this warning, but in this case
+it is expected for the warning to appear every time we are network booting.
 
 ---
 # Recovery

--- a/dug_6_osfv.md
+++ b/dug_6_osfv.md
@@ -28,10 +28,10 @@ class: center, middle, intro
   - testing Dasharo firmware releases
   - test-driven bug fixing (and adding new features)
   - regression testing
-      + after introducing new features
-      + after major changes (update base from upstream project)
+    + after introducing new features
+    + after major changes (update base from upstream project)
   - validation of Dasharo related tools (DTS, DCU)
-      + where possible, in QEMU
+    + where possible, in QEMU
 
 .center.image-20[![](/img/Robot-framework-logo.png)]
 


### PR DESCRIPTION
In my case the warning message did not include a ready-to-use command to remove the identity from known_hosts file. Deleting it manually is just as good.